### PR TITLE
Jest matcher to have style rule works with nested classes

### DIFF
--- a/packages/jest-emotion/src/matchers.js
+++ b/packages/jest-emotion/src/matchers.js
@@ -41,7 +41,7 @@ function toHaveStyleRule(received: *, property: *, value: *) {
   const styles = css.parse(cssString)
 
   const declaration = styles.stylesheet.rules
-    .reduce((decs, rule) => Object.assign([], decs, rule.declarations), [])
+    .reduce((decs, rule) => decs.concat(rule.declarations), [])
     .filter(dec => dec.type === 'declaration' && dec.property === property)
     .pop()
 

--- a/packages/jest-emotion/test/matchers.test.js
+++ b/packages/jest-emotion/test/matchers.test.js
@@ -19,6 +19,14 @@ describe('toHaveStyleRule', () => {
     width: 100%;
   `
 
+  const nestedClassesStyle = emotion.css`
+    color: red;
+
+    &.nested {
+      background-color: blue;
+    }
+  `
+
   const enzymeMethods = ['shallow', 'mount', 'render']
 
   it('matches styles on the top-most node passed in', () => {
@@ -107,6 +115,16 @@ describe('toHaveStyleRule', () => {
   it('supports regex values', () => {
     const tree = renderer.create(<div className={divStyle} />).toJSON()
     expect(tree).toHaveStyleRule('color', /red/)
+  })
+
+  it('includes all styles when using nested classes', () => {
+    const tree = renderer
+      .create(<div className={`${nestedClassesStyle} visible`} />)
+      .toJSON()
+
+    expect(tree).toHaveStyleRule('color', 'red')
+    expect(tree).toHaveStyleRule('background-color', 'blue')
+    expect(tree).not.toHaveStyleRule('width', '100%')
   })
 
   it.skip('returns a message explaining the failure', () => {

--- a/packages/jest-emotion/test/matchers.test.js
+++ b/packages/jest-emotion/test/matchers.test.js
@@ -27,6 +27,14 @@ describe('toHaveStyleRule', () => {
     }
   `
 
+  const nestedClassesWithDuplicateProperties = emotion.css`
+    color: red;
+
+    &.nested {
+      color: blue;
+    }
+  `
+
   const enzymeMethods = ['shallow', 'mount', 'render']
 
   it('matches styles on the top-most node passed in', () => {
@@ -119,11 +127,33 @@ describe('toHaveStyleRule', () => {
 
   it('includes all styles when using nested classes', () => {
     const tree = renderer
-      .create(<div className={`${nestedClassesStyle} visible`} />)
+      .create(<div className={`${nestedClassesStyle} nested`} />)
       .toJSON()
 
     expect(tree).toHaveStyleRule('color', 'red')
     expect(tree).toHaveStyleRule('background-color', 'blue')
+    expect(tree).not.toHaveStyleRule('width', '100%')
+  })
+
+  it('does not include styles from nested classes when the nested class is not present', () => {
+    const tree = renderer
+      .create(<div className={nestedClassesStyle} />)
+      .toJSON()
+
+    expect(tree).toHaveStyleRule('color', 'red')
+    expect(tree).not.toHaveStyleRule('background-color', 'blue')
+    expect(tree).not.toHaveStyleRule('width', '100%')
+  })
+
+  it('includes last style when using nested classes with same css properties', () => {
+    const tree = renderer
+      .create(
+        <div className={`${nestedClassesWithDuplicateProperties} nested`} />
+      )
+      .toJSON()
+
+    expect(tree).not.toHaveStyleRule('color', 'red')
+    expect(tree).toHaveStyleRule('color', 'blue')
     expect(tree).not.toHaveStyleRule('width', '100%')
   })
 


### PR DESCRIPTION
**What**:
The `toHaveStyleRule` matcher in jest-emotion erases styles when using a nested class. For example:
```
  const nestedClassesStyle = emotion.css`
    color: red;

    &.nested {
      background-color: blue;
    }
  `
```
In this case, `toHaveStyleRule` will only see the `background-color: blue` and will report `color: red` as a missing property.

**Why**:
When nesting classes, we want to be able to make assertions against any properties added to the element.

**How**:
The matcher was previously using `Object.assign` on an array, which causes parts of the array with similar keys to be erased, because Object.assign treats the array as an object where the keys are the index of the array. E.g., `['a', 'b']` turns into {1: 'a', 2: 'b'}. So when we combine the arrays, anything with the same index gets removed.
```js
Object.assign(['a'], ['b']) === ['b']
```

**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation - N/A
- [x] Tests
- [x] Code complete

**Additional comments:**
This is only a very basic solution and does not cover all edge cases yet. For example, it doesn't handle cases where the nested selector is not present on the element.

**Update** Looks like this issue was reported in that past here: https://github.com/emotion-js/emotion/issues/791
